### PR TITLE
New sponsoring collector

### DIFF
--- a/bin/sponsoring
+++ b/bin/sponsoring
@@ -1,0 +1,1 @@
+../utils/exec-metric

--- a/metrics/collectors/sponsoring/__init__.py
+++ b/metrics/collectors/sponsoring/__init__.py
@@ -1,0 +1,5 @@
+from metrics.collectors.sponsoring.sponsoring_collector import SponsoringMetrics
+
+
+def run_metric():
+    SponsoringMetrics().run()

--- a/metrics/collectors/sponsoring/__main__.py
+++ b/metrics/collectors/sponsoring/__main__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Canonical Ltd
+from metrics.lib.basemetric import run_metric_main
+
+run_metric_main("metrics.collectors.sponsoring", "SponsoringMetrics")

--- a/metrics/collectors/sponsoring/sponsoring_collector.py
+++ b/metrics/collectors/sponsoring/sponsoring_collector.py
@@ -1,0 +1,29 @@
+# Copyright 2021 Canonical Ltd
+
+import json
+import urllib.request
+
+from metrics.lib.basemetric import Metric
+
+SPONSORING_QUEUE_URL = (
+    "http://reqorts.qa.ubuntu.com/reports/sponsoring/sponsoring.json"
+)
+
+
+class SponsoringMetrics(Metric):
+    def collect(self):
+        """ Collect the sponsoring queue details"""
+        data = []
+
+        with urllib.request.urlopen(SPONSORING_QUEUE_URL) as url:
+            report = json.load(url)
+
+            data.append(
+                {
+                    "measurement": "sponsoring_queue_stats",
+                    "fields": {"count": len(report), },
+                    "tags": {"report": "ubuntu", },
+                }
+            )
+
+        return data


### PR DESCRIPTION
Starting with a trivial version. I've some improvements coming next, collecting some extra stats, but those are pending for changes to the ubuntu-sponsors report to land first (which are ready to be submitted but currently delayed by a launchpad git outage...)