### PR TITLE
Set isort profile instead of black line length

### DIFF
--- a/.github/linters/.isort.cfg
+++ b/.github/linters/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/.github/linters/.python-black
+++ b/.github/linters/.python-black
@@ -1,2 +1,0 @@
-[tool.black]
-line-length = 80

--- a/metrics/collectors/autopkgtest/__init__.py
+++ b/metrics/collectors/autopkgtest/__init__.py
@@ -1,6 +1,4 @@
-from metrics.collectors.autopkgtest.autopkgtest_collector import (
-    AutopkgtestMetrics,
-)
+from metrics.collectors.autopkgtest.autopkgtest_collector import AutopkgtestMetrics
 
 
 def run_metric():

--- a/metrics/collectors/upload_queues/__init__.py
+++ b/metrics/collectors/upload_queues/__init__.py
@@ -1,6 +1,4 @@
-from metrics.collectors.upload_queues.upload_queue_collector import (
-    UbuntuQueueMetrics,
-)
+from metrics.collectors.upload_queues.upload_queue_collector import UbuntuQueueMetrics
 
 
 def run_metric():

--- a/metrics/lib/basemetric.py
+++ b/metrics/lib/basemetric.py
@@ -19,9 +19,7 @@ def run_metric_main(module, cls):
         action="store_true",
         help="Do not act but print what would be submitted",
     )
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Be more verbose"
-    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Be more verbose")
 
     args = parser.parse_args()
 

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -15,8 +15,7 @@ class TestCollector(unittest.TestCase):
         access the internet, so we may want to consider replacing this with
         mocks in future."""
         for (module_loader, name, ispkg) in pkgutil.iter_modules(
-            [os.path.join("metrics", "collectors")],
-            prefix="metrics.collectors.",
+            [os.path.join("metrics", "collectors")], prefix="metrics.collectors."
         ):
             importlib.import_module(name, __package__)
 


### PR DESCRIPTION
isort can have a profile which makes it compatibile with black. Then we
can raise the length to 88, black's default, and the tools won't fight.