### PR TITLE
Roll back super linter to v3.14.5

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -45,7 +45,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v3.14.5
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: metrics


### PR DESCRIPTION
We just got 3.15.5 but it has a bug, see

  https://github.com/github/super-linter/issues/1400