### PR TITLE
images_collector: Skip "ubuntu"

### DIFF
--- a/metrics/collectors/images/images_collector.py
+++ b/metrics/collectors/images/images_collector.py
@@ -73,8 +73,12 @@ class ImagesMetrics(Metric):
 
                 # there are variations of the naming scheme so guess a bit
                 path_table = path.split("/")
+                # "ubuntu" is a convenience symlink. Everything else in there
+                # is found via other directories.
+                if path_table[0] == "ubuntu":
+                    continue
                 # the path starts with a serie name then it's a desktop iso
-                if path_table[0] in self.active_series:
+                elif path_table[0] in self.active_series:
                     flavor = "ubuntu"
                 # or with 'daily-live'
                 elif path_table[0] == "daily-live":


### PR DESCRIPTION
We're getting wrong results returned at the minute. The problem is that
there's a directory called "ubuntu" which contains some *symlinks* to
the Ubuntu daily-canary/live/preinstalled images. This causes us to
record e.g. preinstalled images under the "ubuntu" flavour and report
the wrong size/age.

Since all of these things can be found via top level directories then we
can skip "ubuntu" completely.