### PR TITLE
all __init__.py: Pass any arguments to run_metrics

### DIFF
--- a/metrics/collectors/autopkgtest/__init__.py
+++ b/metrics/collectors/autopkgtest/__init__.py
@@ -1,5 +1,5 @@
 from metrics.collectors.autopkgtest.autopkgtest_collector import AutopkgtestMetrics
 
 
-def run_metric():
-    AutopkgtestMetrics().run()
+def run_metric(*args, **kwargs):
+    AutopkgtestMetrics(*args, **kwargs).run()

--- a/metrics/collectors/images/__init__.py
+++ b/metrics/collectors/images/__init__.py
@@ -1,5 +1,5 @@
 from metrics.collectors.images.images_collector import ImagesMetrics
 
 
-def run_metric():
-    ImagesMetrics().run()
+def run_metric(*args, **kwargs):
+    ImagesMetrics(*args, **kwargs).run()

--- a/metrics/collectors/rls_bugs/__init__.py
+++ b/metrics/collectors/rls_bugs/__init__.py
@@ -3,5 +3,5 @@ from metrics.collectors.rls_bugs.rls_bugs_collector import ReleaseBugsMetrics
 RUN_INTERVAL = "1h"
 
 
-def run_metric():
-    ReleaseBugsMetrics().run()
+def run_metric(*args, **kwargs):
+    ReleaseBugsMetrics(*args, **kwargs).run()

--- a/metrics/collectors/sponsoring/__init__.py
+++ b/metrics/collectors/sponsoring/__init__.py
@@ -1,5 +1,5 @@
 from metrics.collectors.sponsoring.sponsoring_collector import SponsoringMetrics
 
 
-def run_metric():
-    SponsoringMetrics().run()
+def run_metric(*args, **kwargs):
+    SponsoringMetrics(*args, **kwargs).run()

--- a/metrics/collectors/upload_queues/__init__.py
+++ b/metrics/collectors/upload_queues/__init__.py
@@ -1,5 +1,5 @@
 from metrics.collectors.upload_queues.upload_queue_collector import UbuntuQueueMetrics
 
 
-def run_metric():
-    UbuntuQueueMetrics().run()
+def run_metric(*args, **kwargs):
+    UbuntuQueueMetrics(*args, **kwargs).run()

--- a/metrics/collectors/versions/__init__.py
+++ b/metrics/collectors/versions/__init__.py
@@ -3,5 +3,5 @@ from metrics.collectors.versions.versions_collector import VersionsMetrics
 RUN_INTERVAL = "1h"
 
 
-def run_metric():
-    VersionsMetrics().run()
+def run_metric(*args, **kwargs):
+    VersionsMetrics(*args, **kwargs).run()


### PR DESCRIPTION
A change to the charm to come will enable a flag for a "global dry run mode", so we can redeploy to an upcoming new environment in parallel.