### PR TITLE
Add a global dry run mode

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,7 @@ options:
   influxdb-database:
     default: ""
     description: The influxdb database to use
+  dry-run:
+    default: false
+    type: boolean
+    descriptiion: Whether to run in dry-run mode and not submit to the influxdb

--- a/data/run-metric-collector@.service
+++ b/data/run-metric-collector@.service
@@ -5,8 +5,11 @@ Wants=pull-metrics.service
 
 [Service]
 DynamicUser=yes
+# The default value of ${DRY_RUN}
+Environment=DRY_RUN=False
 EnvironmentFile=/srv/influx.conf
-ExecStart=/usr/bin/python3 -c 'from metrics.collectors.%I import run_metric; run_metric()'
+EnvironmentFile=-/srv/dry-run.conf
+ExecStart=/usr/bin/python3 -c 'from metrics.collectors.%I import run_metric; run_metric(dry_run=${DRY_RUN}, verbose=${DRY_RUN})'
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
 PrivateMounts=yes

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,6 +15,7 @@ from ops.framework import StoredState
 logger = logging.getLogger(__name__)
 
 CREDENTIALS_FILE = "/srv/influx.conf"
+DRY_RUN_FILE = "/srv/dry-run.conf"
 METRICS_REPO = "https://github.com/ubuntu/ubuntu-release-metrics.git"
 PACKAGES_TO_INSTALL = ["git", "python3-influxdb", "python3-launchpadlib"]
 
@@ -138,6 +139,18 @@ class UbuntuReleaseMetricsCollectorCharm(CharmBase):
             """
                 )
             )
+
+        dry_run = self.model.config["dry-run"]
+
+        with open(
+            os.open(
+                DRY_RUN_FILE,
+                os.O_CREAT | os.O_TRUNC | os.O_WRONLY,
+                mode=0o600,
+            ),
+            "w",
+        ) as drf:
+            drf.write(f"DRY_RUN={str(dry_run)}\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When we get our new environment for the metrics, we'll want to make sure
everything is working properly before starting to submit to Influx. Use
the functionality from 689111e961155b723d8d16353421a6671c306b37 to
select dry-run/live from the new 'dry-run' config item.