### PR TITLE
New settings for Prodstack 5

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -23,13 +23,12 @@ applications:
       tags: juju-managed
       url: https://landscape.is.canonical.com/message-system
       registration-key: include-file://{{local_dir}}/landscape-registration-key
-  livepatch:
-    charm: canonical-livepatch
+  ua:
+    charm: cs:~ubuntu-advantage-charmers/ubuntu-advantage
     options:
-      livepatch_key: include-file://{{local_dir}}/canonical-is-livepatch-key
-      snap_proxy: http://squid.internal:3128
+      token: include-file://{{local_dir}}/canonical-is-ua.key
 relations:
   - ["ubuntu-release-metrics-collector:juju-info", "telegraf"]
-  - ["livepatch", "ubuntu-release-metrics-collector"]
+  - ["ua", "ubuntu-release-metrics-collector"]
   - ["landscape-client", "ubuntu-release-metrics-collector"]
 {%- endif %}

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -8,6 +8,9 @@ applications:
       influxdb-username: metrics
       influxdb-password: include-file://{{ local_dir }}/influx-password.txt
       influxdb-database: metrics
+      http-proxy: http://squid.internal:3128
+      https-proxy: http://squid.internal:3128
+      no-proxy: 127.0.0.1,::1,localhost,10.0.0.0/8,canonical.com,ubuntu.com,launchpad.net,internal
 {%- if stage_name == "production" or stage_name == "staging" %}
   telegraf:
     charm: telegraf


### PR DESCRIPTION
We need to set the proxy in the charm, and we need to switch to using `ua` instead of `livepatch`.