### PR TITLE
Fix an image parsing error due to the new ubuntu-mini-iso

### DIFF
--- a/metrics/collectors/images/images_collector.py
+++ b/metrics/collectors/images/images_collector.py
@@ -9,11 +9,11 @@ from launchpadlib.launchpad import Launchpad
 from metrics.lib.basemetric import Metric
 
 RSYNC_SERVER_REQUESTS = [
-    "rsync://cdimage.ubuntu.com/cdimage/daily*/*/*.",
-    "rsync://cdimage.ubuntu.com/cdimage/*/daily*/*/*.",
-    "rsync://cdimage.ubuntu.com/cdimage/*/*/daily*/*/*.",
+    "rsync://cdimage.ubuntu.com/cdimage/daily*/*/*",
+    "rsync://cdimage.ubuntu.com/cdimage/*/daily*/*/*",
+    "rsync://cdimage.ubuntu.com/cdimage/*/*/daily*/*/*",
 ]
-IMAGE_FORMATS = ["iso", "img.xz"]
+IMAGE_FORMATS = [".iso", ".img.xz"]
 
 
 class ImagesMetrics(Metric):


### PR DESCRIPTION
We assumed that an entry matching 'iso' was an image and not a directory, but it's not the case with 'ubuntu-mini-iso', add the dot in the filter to ensure we only include filenames