### PR TITLE
ubuntustudio does not have a a daily directory but a dvd one

### DIFF
--- a/metrics/collectors/images/images_collector.py
+++ b/metrics/collectors/images/images_collector.py
@@ -11,7 +11,9 @@ from metrics.lib.basemetric import Metric
 RSYNC_SERVER_REQUESTS = [
     "rsync://cdimage.ubuntu.com/cdimage/daily*/*/*",
     "rsync://cdimage.ubuntu.com/cdimage/*/daily*/*/*",
+    "rsync://cdimage.ubuntu.com/cdimage/*/dvd/*/*",
     "rsync://cdimage.ubuntu.com/cdimage/*/*/daily*/*/*",
+    "rsync://cdimage.ubuntu.com/cdimage/*/*/dvd/*/*",
 ]
 IMAGE_FORMATS = [".iso", ".img.xz"]
 


### PR DESCRIPTION
We currently don't have any stats on Ubuntu Studio image size or age due its special snowflake directory. This resolves that. It's worth mentioning I did see this error when testing it but don't think it is **important**.

```
INFO - Running in dry-run mode.
rsync: link_stat "/*/dvd/*/*.img.xz" (in cdimage) failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1865) [Receiver=3.2.7]
ERROR - rsync call failed: This is an Ubuntu mirror - treat it kindly
```
