### PR TITLE
Do not traceback on a urlerror when fetching autopkgtest queues

### DIFF
--- a/metrics/collectors/autopkgtest/autopkgtest_collector.py
+++ b/metrics/collectors/autopkgtest/autopkgtest_collector.py
@@ -19,13 +19,18 @@ RUNNING_URL = {
 
 class AutopkgtestMetrics(Metric):
     def fetch(self, url):
-        with urllib.request.urlopen(url) as resp:
-            return json.load(resp)
+        try:
+            with urllib.request.urlopen(url) as resp:
+                return json.load(resp)
+        except urllib.error.URLError:
+            return []
 
     def collect_queue_sizes(self):
         data = []
         for instance in ("production", "staging"):
             queue_sizes = self.fetch(QUEUE_SIZE_URL[instance])
+            if not queue_sizes:
+                continue
             for context in queue_sizes:
                 for release in queue_sizes[context]:
                     for arch, count in queue_sizes[context][release].items():


### PR DESCRIPTION
The staging version of autopkgtest.ubuntu.com was down and that caused a Traceback trying to get stats for that environment and subsequently we could not get stats for production.

 python3[702585]: Traceback (most recent call last):
 python3[702585]:   File "<string>", line 1, in <module>
 python3[702585]:   File "/srv/ubuntu-release-metrics/metrics/collectors/autopkgtest/__init__.py", line 5, in run_metric
 python3[702585]:     AutopkgtestMetrics(*args, **kwargs).run()
 python3[702585]:   File "/srv/ubuntu-release-metrics/metrics/lib/basemetric.py", line 73, in run
 python3[702585]:     data = self.collect()
 python3[702585]:   File "/srv/ubuntu-release-metrics/metrics/collectors/autopkgtest/autopkgtest_collector.py", line 75, in co>
 python3[702585]:     d1 = self.collect_queue_sizes()
 python3[702585]:   File "/srv/ubuntu-release-metrics/metrics/collectors/autopkgtest/autopkgtest_collector.py", line 28, in co>
 python3[702585]:     queue_sizes = self.fetch(QUEUE_SIZE_URL[instance])
 python3[702585]:   File "/srv/ubuntu-release-metrics/metrics/collectors/autopkgtest/autopkgtest_collector.py", line 22, in fe>
 python3[702585]:     with urllib.request.urlopen(url) as resp:
 python3[702585]:   File "/usr/lib/python3.8/urllib/request.py", line 222, in urlopen
 python3[702585]:     return opener.open(url, data, timeout)
 python3[702585]:   File "/usr/lib/python3.8/urllib/request.py", line 525, in open
 python3[702585]:     response = self._open(req, data)
 python3[702585]:   File "/usr/lib/python3.8/urllib/request.py", line 542, in _open
 python3[702585]:     result = self._call_chain(self.handle_open, protocol, protocol +
 python3[702585]:   File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
 python3[702585]:     result = func(*args)
 python3[702585]:   File "/usr/lib/python3.8/urllib/request.py", line 1397, in https_open
 python3[702585]:     return self.do_open(http.client.HTTPSConnection, req,
 python3[702585]:   File "/usr/lib/python3.8/urllib/request.py", line 1357, in do_open
 python3[702585]:     raise URLError(err)
 python3[702585]: urllib.error.URLError: <urlopen error [Errno 113] No route to host>
