### PR TITLE
rls_bugs_collector.py: switch to http and reports

### DIFF
--- a/metrics/collectors/rls_bugs/rls_bugs_collector.py
+++ b/metrics/collectors/rls_bugs/rls_bugs_collector.py
@@ -9,10 +9,10 @@ from metrics.lib.basemetric import Metric
 from metrics.lib.ubunturelease import UbuntuRelease
 
 INCOMING_URL_PATTERN = (
-    "https://reqorts.qa.ubuntu.com/reports/rls-mgr/rls-{}-incoming.json"
+    "http://reports.qa.ubuntu.com/reports/rls-mgr/rls-{}-incoming.json"
 )
 TRACKING_URL_PATTERN = (
-    "https://reqorts.qa.ubuntu.com/reports/rls-mgr/rls-{}-tracking.json"
+    "http://reports.qa.ubuntu.com/reports/rls-mgr/rls-{}-tracking.json"
 )
 
 


### PR DESCRIPTION
The server with the rls reports moved to PS5 and now has a DNS entry for reports.qa.ubuntu.com and does not support SSL.