### PR TITLE
Add .wsl image format to track WSL images

### DIFF
--- a/metrics/collectors/images/images_collector.py
+++ b/metrics/collectors/images/images_collector.py
@@ -15,7 +15,7 @@ RSYNC_SERVER_REQUESTS = [
     "rsync://cdimage.ubuntu.com/cdimage/*/*/daily*/*/*",
     "rsync://cdimage.ubuntu.com/cdimage/*/*/dvd/*/*",
 ]
-IMAGE_FORMATS = [".iso", ".img.xz"]
+IMAGE_FORMATS = [".iso", ".img.xz", ".wsl"]
 
 UBUNTUSTUDIO_DVD_RELEASES = ["jammy", "noble"]
 


### PR DESCRIPTION
This will help us in tracking Ubuntu WSL images we build in the KPI metrics.