### PR TITLE
service: remove MemoryDenyWriteExecute constraint

### DIFF
--- a/data/run-metric-collector@.service
+++ b/data/run-metric-collector@.service
@@ -11,7 +11,6 @@ EnvironmentFile=/home/ubuntu/.local/share/influx.conf
 EnvironmentFile=-/home/ubuntu/.local/share/dry-run.conf
 EnvironmentFile=-/home/ubuntu/.local/share/proxy.conf
 ExecStart=/usr/bin/python3 -c 'from metrics.collectors.%I import run_metric; run_metric(dry_run=${DRY_RUN}, verbose=${DRY_RUN})'
-MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
 PrivateMounts=yes
 PrivateUsers=yes


### PR DESCRIPTION
The MemoryDenyWriteExecute=yes constraint on the service was causing issues with pyOpenSSL, and no justification was provided as to why it's necessary, so I've removed it.