### PR TITLE
images: include more artifacts

### DIFF
--- a/metrics/collectors/images/images_collector.py
+++ b/metrics/collectors/images/images_collector.py
@@ -10,7 +10,7 @@ from launchpadlib.launchpad import Launchpad
 from metrics.lib.basemetric import Metric
 
 RSYNC_SERVER_REQUEST = "rsync://cdimage.ubuntu.com/cdimage/"
-IMAGE_FORMATS = [".iso", ".img.xz", ".wsl"]
+IMAGE_FORMATS = [".iso", ".img.xz", ".tar.gz", ".wsl"]
 
 UBUNTUSTUDIO_DVD_RELEASES = ["jammy", "noble"]
 

--- a/metrics/collectors/images/images_collector.py
+++ b/metrics/collectors/images/images_collector.py
@@ -87,6 +87,11 @@ class ImagesMetrics(Metric):
                     if starts_with_daily or part_of_path == "dvd":
                         image_type = part_of_path.replace("daily-", "")
                         break
+
+                # let's filter out hidden files that sometimes show up
+                if image_name.startswith("."):
+                    continue
+
                 # let's filter out old ubuntu-core-16 images
                 if image_name.startswith("ubuntu-core-16"):
                     continue


### PR DESCRIPTION
Include `.tar.gz` artifacts (netboot and base).